### PR TITLE
fixing positioning of the listing

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -11,23 +11,24 @@
 </head>
 <body>
 	<div class="container">
-	  <div class="jumbotron">
-	  	<h1>OpenAperture</h1>
-	  	<!--<img src="images/oagraphic.png" style="max-height: 150px; max-width: 150px;" class="pull-right"><h1>OpenAperture</h1></img>-->
-	    <p>Cloud Application Management Platform</p> 
-	  </div>
-	  <div class="row">
+		<div class="jumbotron">
+	  		<h1>OpenAperture</h1>
+	  		<!--<img src="images/oagraphic.png" style="max-height: 150px; max-width: 150px;" class="pull-right"><h1>OpenAperture</h1></img>-->
+	    		<p>Cloud Application Management Platform</p> 
+	  	</div>
+		<div class="row">
 			<p class="col-md-12 lead">
 				Products that are being developed for deployment into the Cloud should follow the guidance provided by <a href="http://12factor.net/" target="_blank">The 12 Factor App</a>. As a result of how OpenAperture deploys products, there are several design constraints that should be considered:
 			</p>
-			<br/>
+		</div>
+		<div class="row">
 			<ul class="lead">
 				<li>Products must be able to scale horizontally.</li>
 				<li>Products must be able to accept configuration via environment variables (i.e. database URLs, etc...).</li>
 				<li>Products must be dockerizable. Currently, this requires products to run in a Linux environment.</li>
 			</ul>							
 		</div>
-		<br/>
+		<br>
 	</div>
 
 	<div class="footer navbar-fixed-bottom">


### PR DESCRIPTION
at least on mac osx in chrome 41 the dot for the listing of the first entry was on the wrong side
